### PR TITLE
Android PDF Intent Handling and Launch Mode Updates

### DIFF
--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -12,6 +12,9 @@ public partial class AppShell : Shell
     {
         InitializeComponent();
         
+        // Register MainPage
+        Routing.RegisterRoute("MainPage", typeof(MainPage));
+        
         // Register InfoViews
         Routing.RegisterRoute("CustomerInfo", typeof(CustomerInfoPage));
         Routing.RegisterRoute("DeviceInfo", typeof(DeviceInfoPage));

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -143,6 +143,8 @@ public partial class MainPage : ContentPage
     {
         try
         {
+            System.Diagnostics.Debug.WriteLine("[MainPage] HandlePdfIntent called with URI: " + pdfUri);
+            
             // Get Intent File Stream
             var pdfIntentHelper = IPlatformApplication.Current?.Services.GetService<IPdfIntentHelper>();
             var pdfStream = await pdfIntentHelper.GetPdfStream(pdfUri);

--- a/Platforms/Android/AndroidManifest.xml
+++ b/Platforms/Android/AndroidManifest.xml
@@ -9,6 +9,7 @@
 		<activity android:name="anybackflow.reportflow.activity"
 				  android:configChanges="density|orientation|smallestScreenSize|screenLayout|screenSize|uiMode"
 				  android:theme="@style/Maui.SplashTheme"
+				  android:launchMode="singleTask"
 				  android:exported="true">
 			<!-- Launch from app icon -->
 			<intent-filter>

--- a/Platforms/Android/MainActivity.cs
+++ b/Platforms/Android/MainActivity.cs
@@ -5,7 +5,8 @@ using Android.OS;
 
 namespace ReportFlow;
 
-[Activity(Name="anybackflow.reportflow.activity", Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop,
+[Activity(Name = "anybackflow.reportflow.activity", Theme = "@style/Maui.SplashTheme", MainLauncher = true,
+    LaunchMode = LaunchMode.SingleTask,
     ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
                            ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
@@ -13,11 +14,22 @@ public class MainActivity : MauiAppCompatActivity
     protected override void OnNewIntent(Intent? intent)
     {
         base.OnNewIntent(intent);
+        System.Diagnostics.Debug.WriteLine("[MainActivity] OnNewIntent called");
 
         if (intent?.Data != null)
         {
-            var mainPage = Microsoft.Maui.Controls.Application.Current?.MainPage as MainPage;
-            mainPage?.HandlePdfIntent(new Uri(intent.Data.ToString() ?? throw new InvalidOperationException()));
+            System.Diagnostics.Debug.WriteLine("[MainActivity] Intent Data is valid");
+            
+            MainThread.BeginInvokeOnMainThread(async () =>
+            {
+                await Shell.Current.GoToAsync("///MainPage");
+            
+                if (Shell.Current?.CurrentPage is MainPage mainPage)
+                {
+                    mainPage.HandlePdfIntent(new Uri(intent.Data.ToString() ?? 
+                                                     throw new InvalidOperationException()));
+                }
+            });
         }
     }
 }

--- a/ReportFlow.csproj
+++ b/ReportFlow.csproj
@@ -18,7 +18,7 @@
         <ApplicationId>com.anybackflow.reportflow</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>1.2.1</ApplicationDisplayVersion>
+        <ApplicationDisplayVersion>1.2.2</ApplicationDisplayVersion>
         <ApplicationVersion>1</ApplicationVersion>
         
         <!-- Build Time Optimization -->


### PR DESCRIPTION
### Changes
- Added debug logging to `MainPage` and Android `MainActivity` to improve tracking of PDF intent behavior
- Updated intent handling logic to navigate to `MainPage` proactively
- Adjusted Android `MainPage` launch mode to use `singleTask`
- Bumped app version to 1.2.2

## Purpose
These changes improve the PDF opening experience by ensuring more reliable navigation flow and better activity state management. The enhanced logging will help with debugging intent-related issues.
