### PR TITLE
Implement settings page and auto-filled text-based input fields

### DIFF
--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -2,6 +2,7 @@
 using ReportFlow.Views.InfoViews;
 using ReportFlow.Views.RepairViews;
 using ReportFlow.Views.ReportViews;
+using ReportFlow.Views.SettingsView;
 using ReportFlow.Views.TestViews;
 
 namespace ReportFlow;
@@ -14,6 +15,9 @@ public partial class AppShell : Shell
 
         // Register MainPage
         Routing.RegisterRoute("MainPage", typeof(MainPage));
+
+        // Register Settings Page
+        Routing.RegisterRoute("SettingsPage", typeof(SettingsViewPage));
 
         // Register Report Browser
         Routing.RegisterRoute("ReportBrowser", typeof(ReportBrowserPage));

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -190,10 +190,6 @@ public partial class MainPage : ContentPage
 
     private async void OnSettingsClicked(object? sender, EventArgs e)
     {
-        await Application.Current.MainPage.DisplayAlert(
-            "Not Implemented",
-            $"The settings page is not implemented yet.",
-            "OK"
-        );
+        await Shell.Current.GoToAsync("SettingsPage");
     }
 }

--- a/Models/Final/FinalInfo.cs
+++ b/Models/Final/FinalInfo.cs
@@ -3,7 +3,7 @@
 public class TesterInfo
 {
     public string? Name { get; set; } = string.Empty;
-    public string? CertificationNo { get; set; } = string.Empty;
+    public string? CertNo { get; set; } = string.Empty;
     public string? TestKitSerial { get; set; } = string.Empty;
     public DateTime Date { get; set; } = DateTime.Today;
 }
@@ -22,7 +22,7 @@ public class FinalInfo
         if (InitialTest != null)
         {
             fields.Add("InitialTester", InitialTest.Name ?? string.Empty);
-            fields.Add("InitialTesterNo", InitialTest.CertificationNo ?? string.Empty);
+            fields.Add("InitialTesterNo", InitialTest.CertNo ?? string.Empty);
             fields.Add("InitialTestKitSerial", InitialTest.TestKitSerial ?? string.Empty);
             if (!string.IsNullOrEmpty(InitialTest.Name))
                 fields.Add("DateFailed", InitialTest.Date.ToString("M/d/yyyy"));
@@ -31,7 +31,7 @@ public class FinalInfo
         if (RepairedTest != null)
         {
             fields.Add("RepairedTester", RepairedTest.Name ?? string.Empty);
-            fields.Add("RepairedTesterNo", RepairedTest.CertificationNo ?? string.Empty);
+            fields.Add("RepairedTesterNo", RepairedTest.CertNo ?? string.Empty);
             fields.Add("RepairedTestKitSerial", RepairedTest.TestKitSerial ?? string.Empty);
             if (!string.IsNullOrEmpty(RepairedTest.Name))
                 fields.Add("DateRepaired", RepairedTest.Date.ToString("M/d/yyyy"));
@@ -40,7 +40,7 @@ public class FinalInfo
         if (FinalTest != null)
         {
             fields.Add("FinalTester", FinalTest.Name ?? string.Empty);
-            fields.Add("FinalTesterNo", FinalTest.CertificationNo ?? string.Empty);
+            fields.Add("FinalTesterNo", FinalTest.CertNo ?? string.Empty);
             fields.Add("FinalTestKitSerial", FinalTest.TestKitSerial ?? string.Empty);
             if (!string.IsNullOrEmpty(FinalTest.Name))
                 fields.Add("DatePassed", FinalTest.Date.ToString("M/d/yyyy"));
@@ -52,27 +52,35 @@ public class FinalInfo
 
     public static FinalInfo FromFormFields(Dictionary<string, string> formData)
     {
+        var defaults = new
+        {
+            TesterName = Preferences.Default.Get("TesterName", string.Empty),
+            TestKitSerial = Preferences.Default.Get("TestKitSerial", string.Empty),
+            TestCertNo = Preferences.Default.Get("CertNo", string.Empty),
+            RepairCertNo = Preferences.Default.Get("RepairCertNo", string.Empty)
+        };
+
         return new FinalInfo
         {
             InitialTest = new TesterInfo
             {
-                Name = formData.GetValueOrDefault("InitialTester"),
-                CertificationNo = formData.GetValueOrDefault("InitialTesterNo"),
-                TestKitSerial = formData.GetValueOrDefault("InitialTestKitSerial"),
+                Name = formData.GetValueOrDefault("InitialTester", defaults.TesterName),
+                CertNo = formData.GetValueOrDefault("InitialTesterNo", defaults.TestCertNo),
+                TestKitSerial = formData.GetValueOrDefault("InitialTestKitSerial", defaults.TestKitSerial),
                 Date = DateTime.Parse(formData.GetValueOrDefault("DateFailed") ?? DateTime.Today.ToString("M/d/yyyy"))
             },
             RepairedTest = new TesterInfo
             {
-                Name = formData.GetValueOrDefault("RepairedTester"),
-                CertificationNo = formData.GetValueOrDefault("RepairedTesterNo"),
-                TestKitSerial = formData.GetValueOrDefault("RepairedTestKitSerial"),
+                Name = formData.GetValueOrDefault("RepairedTester", defaults.TesterName),
+                CertNo = formData.GetValueOrDefault("RepairedTesterNo", defaults.RepairCertNo),
+                TestKitSerial = formData.GetValueOrDefault("RepairedTestKitSerial", defaults.TestKitSerial),
                 Date = DateTime.Parse(formData.GetValueOrDefault("DateRepaired") ?? DateTime.Today.ToString("M/d/yyyy"))
             },
             FinalTest = new TesterInfo
             {
-                Name = formData.GetValueOrDefault("FinalTester"),
-                CertificationNo = formData.GetValueOrDefault("FinalTesterNo"),
-                TestKitSerial = formData.GetValueOrDefault("FinalTestKitSerial"),
+                Name = formData.GetValueOrDefault("FinalTester", defaults.TesterName),
+                CertNo = formData.GetValueOrDefault("FinalTesterNo", defaults.TestCertNo),
+                TestKitSerial = formData.GetValueOrDefault("FinalTestKitSerial", defaults.TestKitSerial),
                 Date = DateTime.Parse(formData.GetValueOrDefault("DatePassed") ?? DateTime.Today.ToString("M/d/yyyy"))
             },
             Comments = formData.GetValueOrDefault("ReportComments")

--- a/ReportFlow.csproj
+++ b/ReportFlow.csproj
@@ -18,7 +18,7 @@
         <ApplicationId>com.anybackflow.reportflow</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>1.8.4</ApplicationDisplayVersion>
+        <ApplicationDisplayVersion>1.9.0</ApplicationDisplayVersion>
         <ApplicationVersion>1</ApplicationVersion>
 
         <!-- Build Time Optimization -->

--- a/ViewModels/FinalViewModels/FinalViewModel.cs
+++ b/ViewModels/FinalViewModels/FinalViewModel.cs
@@ -46,22 +46,6 @@ public class FinalViewModel : BaseBackflowViewModel
 
     #endregion
 
-    #region Dropdown Items
-
-    public List<string> TesterNameOptions { get; } =
-        ["MIGUEL CARRILLO", "JAYSON PADILLA", "JACOB S. PADILLA"];
-
-    public List<string> TesterNoOptions { get; } =
-    [
-        "03-2105139", "03-2106135", "03-2105140",
-        "40604", "42332", "40609", "60291"
-    ];
-
-    public List<string> TestKitSerialOptions { get; } =
-        ["02130411", "06122624", "03100226", "10171937", "07172355"];
-
-    #endregion
-
     #region Initial Test Properties
 
     public string? InitialTester
@@ -77,11 +61,11 @@ public class FinalViewModel : BaseBackflowViewModel
 
     public string? InitialTesterNo
     {
-        get => Report.FinalInfo.InitialTest?.CertificationNo;
+        get => Report.FinalInfo.InitialTest?.CertNo;
         set
         {
             Report.FinalInfo.InitialTest ??= new TesterInfo();
-            Report.FinalInfo.InitialTest.CertificationNo = value;
+            Report.FinalInfo.InitialTest.CertNo = value;
             OnPropertyChanged(nameof(InitialTesterNo));
         }
     }
@@ -125,11 +109,11 @@ public class FinalViewModel : BaseBackflowViewModel
 
     public string? RepairedTesterNo
     {
-        get => Report.FinalInfo.RepairedTest?.CertificationNo;
+        get => Report.FinalInfo.RepairedTest?.CertNo;
         set
         {
             Report.FinalInfo.RepairedTest ??= new TesterInfo();
-            Report.FinalInfo.RepairedTest.CertificationNo = value;
+            Report.FinalInfo.RepairedTest.CertNo = value;
             OnPropertyChanged(nameof(RepairedTesterNo));
         }
     }
@@ -173,11 +157,11 @@ public class FinalViewModel : BaseBackflowViewModel
 
     public string? FinalTesterNo
     {
-        get => Report.FinalInfo.FinalTest?.CertificationNo;
+        get => Report.FinalInfo.FinalTest?.CertNo;
         set
         {
             Report.FinalInfo.FinalTest ??= new TesterInfo();
-            Report.FinalInfo.FinalTest.CertificationNo = value;
+            Report.FinalInfo.FinalTest.CertNo = value;
             OnPropertyChanged(nameof(FinalTesterNo));
         }
     }

--- a/ViewModels/SettingsViewModel/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel/SettingsViewModel.cs
@@ -86,7 +86,7 @@ public class SettingsViewModel : INotifyPropertyChanged
         {
             Preferences.Default.Set("TesterName", TesterName);
             Preferences.Default.Set("TestKitSerial", TestKitSerial);
-            Preferences.Default.Set("TestCertNo", TestCertNo);
+            Preferences.Default.Set("CertNo", TestCertNo);
             Preferences.Default.Set("RepairCertNo", RepairCertNo);
 
             await Shell.Current.DisplayAlert("Success", "Settings saved successfully", "OK");

--- a/ViewModels/SettingsViewModel/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel/SettingsViewModel.cs
@@ -1,0 +1,112 @@
+﻿using System.ComponentModel;
+using System.Windows.Input;
+
+namespace ReportFlow.ViewModels.SettingsViewModel;
+
+public class SettingsViewModel : INotifyPropertyChanged
+{
+    #region Private Fields
+
+    private string _testerName;
+    private string _testKitSerial;
+    private string _testCertNo;
+    private string _repairCertNo;
+    private ICommand _saveCommand;
+
+    #endregion
+
+    #region Public Properties
+
+    public string TesterName
+    {
+        get => _testerName;
+        set
+        {
+            _testerName = value;
+            OnPropertyChanged(nameof(TesterName));
+        }
+    }
+
+    public string TestKitSerial
+    {
+        get => _testKitSerial;
+        set
+        {
+            _testKitSerial = value;
+            OnPropertyChanged(nameof(TestKitSerial));
+        }
+    }
+
+    public string TestCertNo
+    {
+        get => _testCertNo;
+        set
+        {
+            _testCertNo = value;
+            OnPropertyChanged(nameof(TestCertNo));
+        }
+    }
+
+    public string RepairCertNo
+    {
+        get => _repairCertNo;
+        set
+        {
+            _repairCertNo = value;
+            OnPropertyChanged(nameof(RepairCertNo));
+        }
+    }
+
+    public ICommand SaveCommand => _saveCommand ??= new Command(async () => await Save());
+
+    #endregion
+
+    #region Constructor and Initialization
+
+    public SettingsViewModel()
+    {
+        LoadSaveSettings();
+    }
+
+    public void LoadSaveSettings()
+    {
+        TesterName = Preferences.Get(nameof(TesterName), string.Empty);
+        TestKitSerial = Preferences.Get(nameof(TestKitSerial), string.Empty);
+        TestCertNo = Preferences.Get(nameof(TestCertNo), string.Empty);
+        RepairCertNo = Preferences.Get(nameof(RepairCertNo), string.Empty);
+    }
+
+    #endregion
+
+    #region Commands Implementation
+
+    private async Task Save()
+    {
+        try
+        {
+            Preferences.Default.Set("TesterName", TesterName);
+            Preferences.Default.Set("TestKitSerial", TestKitSerial);
+            Preferences.Default.Set("TestCertNo", TestCertNo);
+            Preferences.Default.Set("RepairCertNo", RepairCertNo);
+
+            await Shell.Current.DisplayAlert("Success", "Settings saved successfully", "OK");
+        }
+        catch
+        {
+            await Shell.Current.DisplayAlert("Error", "Failed to save settings", "OK");
+        }
+    }
+
+    #endregion
+
+    #region INotifyPropertyChanged Implementation
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void OnPropertyChanged(string propertyName)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+
+    #endregion
+}

--- a/Views/FinalViews/FinalView.xaml
+++ b/Views/FinalViews/FinalView.xaml
@@ -42,13 +42,9 @@
                             <Label
                                 Grid.Column="0"
                                 Grid.Row="0"
-                                Style="{StaticResource PickerLabel}"
+                                Style="{StaticResource FieldLabel}"
                                 Text="Tester Name"
-                                x:Name="InitialTesterLabel">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer CommandParameter="{x:Reference InitialTesterPicker}" Tapped="OnLabelTapped" />
-                                </Label.GestureRecognizers>
-                            </Label>
+                                x:Name="InitialTesterLabel" />
 
                             <Label
                                 Grid.Column="1"
@@ -62,13 +58,12 @@
                             </Label>
 
                             <!--  Inputs Row  -->
-                            <Picker
+                            <Entry
                                 Grid.Column="0"
                                 Grid.Row="1"
-                                ItemsSource="{Binding TesterNameOptions}"
-                                SelectedItem="{Binding InitialTester}"
-                                Style="{StaticResource FormPicker}"
-                                x:Name="InitialTesterPicker" />
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding InitialTester}"
+                                x:Name="InitialTester" />
 
                             <DatePicker
                                 Date="{Binding DateFailed}"
@@ -88,40 +83,30 @@
                             <Label
                                 Grid.Column="0"
                                 Grid.Row="0"
-                                Style="{StaticResource PickerLabel}"
+                                Style="{StaticResource FieldLabel}"
                                 Text="Certified Tester No."
-                                x:Name="InitialTesterNoLabel">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer CommandParameter="{x:Reference InitialTesterNoPicker}" Tapped="OnLabelTapped" />
-                                </Label.GestureRecognizers>
-                            </Label>
+                                x:Name="InitialTesterNoLabel" />
 
                             <Label
                                 Grid.Column="1"
                                 Grid.Row="0"
-                                Style="{StaticResource PickerLabel}"
+                                Style="{StaticResource FieldLabel}"
                                 Text="Test Kit Serial"
-                                x:Name="InitialTestKitLabel">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer CommandParameter="{x:Reference InitialTestKitPicker}" Tapped="OnLabelTapped" />
-                                </Label.GestureRecognizers>
-                            </Label>
+                                x:Name="InitialTestKitLabel" />
 
                             <!--  Inputs Row  -->
-                            <Picker
+                            <Entry
                                 Grid.Column="0"
                                 Grid.Row="1"
-                                ItemsSource="{Binding TesterNoOptions}"
-                                SelectedItem="{Binding InitialTesterNo}"
-                                Style="{StaticResource FormPicker}"
-                                x:Name="InitialTesterNoPicker" />
-                            <Picker
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding InitialTesterNo}"
+                                x:Name="InitialTesterNo" />
+                            <Entry
                                 Grid.Column="1"
                                 Grid.Row="1"
-                                ItemsSource="{Binding TestKitSerialOptions}"
-                                SelectedItem="{Binding InitialTestKitSerial}"
-                                Style="{StaticResource FormPicker}"
-                                x:Name="InitialTestKitPicker" />
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding InitialTestKitSerial}"
+                                x:Name="InitialTestKit" />
                         </Grid>
                     </VerticalStackLayout>
                 </VerticalStackLayout>
@@ -149,13 +134,9 @@
                             <Label
                                 Grid.Column="0"
                                 Grid.Row="0"
-                                Style="{StaticResource PickerLabel}"
+                                Style="{StaticResource FieldLabel}"
                                 Text="Tester Name"
-                                x:Name="RepairedTesterLabel">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer CommandParameter="{x:Reference RepairedTesterPicker}" Tapped="OnLabelTapped" />
-                                </Label.GestureRecognizers>
-                            </Label>
+                                x:Name="RepairedTesterLabel" />
 
                             <Label
                                 Grid.Column="1"
@@ -169,13 +150,12 @@
                             </Label>
 
                             <!--  Inputs Row  -->
-                            <Picker
+                            <Entry
                                 Grid.Column="0"
                                 Grid.Row="1"
-                                ItemsSource="{Binding TesterNameOptions}"
-                                SelectedItem="{Binding RepairedTester}"
-                                Style="{StaticResource FormPicker}"
-                                x:Name="RepairedTesterPicker" />
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding RepairedTester}"
+                                x:Name="RepairedTester" />
 
                             <DatePicker
                                 Date="{Binding DateRepaired}"
@@ -195,40 +175,30 @@
                             <Label
                                 Grid.Column="0"
                                 Grid.Row="0"
-                                Style="{StaticResource PickerLabel}"
+                                Style="{StaticResource FieldLabel}"
                                 Text="Certified Tester No."
-                                x:Name="RepairedTesterNoLabel">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer CommandParameter="{x:Reference RepairedTesterNoPicker}" Tapped="OnLabelTapped" />
-                                </Label.GestureRecognizers>
-                            </Label>
+                                x:Name="RepairedTesterNoLabel" />
 
                             <Label
                                 Grid.Column="1"
                                 Grid.Row="0"
-                                Style="{StaticResource PickerLabel}"
+                                Style="{StaticResource FieldLabel}"
                                 Text="Test Kit Serial"
-                                x:Name="RepairedTestKitLabel">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer CommandParameter="{x:Reference RepairedTestKitPicker}" Tapped="OnLabelTapped" />
-                                </Label.GestureRecognizers>
-                            </Label>
+                                x:Name="RepairedTestKitLabel" />
 
                             <!--  Inputs Row  -->
-                            <Picker
+                            <Entry
                                 Grid.Column="0"
                                 Grid.Row="1"
-                                ItemsSource="{Binding TesterNoOptions}"
-                                SelectedItem="{Binding RepairedTesterNo}"
-                                Style="{StaticResource FormPicker}"
-                                x:Name="RepairedTesterNoPicker" />
-                            <Picker
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding RepairedTesterNo}"
+                                x:Name="RepairedTesterNo" />
+                            <Entry
                                 Grid.Column="1"
                                 Grid.Row="1"
-                                ItemsSource="{Binding TestKitSerialOptions}"
-                                SelectedItem="{Binding RepairedTestKitSerial}"
-                                Style="{StaticResource FormPicker}"
-                                x:Name="RepairedTestKitPicker" />
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding RepairedTestKitSerial}"
+                                x:Name="RepairedTestKit" />
                         </Grid>
                     </VerticalStackLayout>
                 </VerticalStackLayout>
@@ -256,13 +226,9 @@
                             <Label
                                 Grid.Column="0"
                                 Grid.Row="0"
-                                Style="{StaticResource PickerLabel}"
+                                Style="{StaticResource FieldLabel}"
                                 Text="Tester Name"
-                                x:Name="FinalTesterLabel">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer CommandParameter="{x:Reference FinalTesterPicker}" Tapped="OnLabelTapped" />
-                                </Label.GestureRecognizers>
-                            </Label>
+                                x:Name="FinalTesterLabel" />
 
                             <Label
                                 Grid.Column="1"
@@ -276,13 +242,12 @@
                             </Label>
 
                             <!--  Inputs Row  -->
-                            <Picker
+                            <Entry
                                 Grid.Column="0"
                                 Grid.Row="1"
-                                ItemsSource="{Binding TesterNameOptions}"
-                                SelectedItem="{Binding FinalTester}"
-                                Style="{StaticResource FormPicker}"
-                                x:Name="FinalTesterPicker" />
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding FinalTester}"
+                                x:Name="FinalTester" />
 
                             <DatePicker
                                 Date="{Binding DatePassed}"
@@ -302,40 +267,30 @@
                             <Label
                                 Grid.Column="0"
                                 Grid.Row="0"
-                                Style="{StaticResource PickerLabel}"
+                                Style="{StaticResource FieldLabel}"
                                 Text="Certified Tester No."
-                                x:Name="FinalTesterNoLabel">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer CommandParameter="{x:Reference FinalTesterNoPicker}" Tapped="OnLabelTapped" />
-                                </Label.GestureRecognizers>
-                            </Label>
+                                x:Name="FinalTesterNoLabel" />
 
                             <Label
                                 Grid.Column="1"
                                 Grid.Row="0"
-                                Style="{StaticResource PickerLabel}"
+                                Style="{StaticResource FieldLabel}"
                                 Text="Test Kit Serial"
-                                x:Name="FinalTestKitLabel">
-                                <Label.GestureRecognizers>
-                                    <TapGestureRecognizer CommandParameter="{x:Reference FinalTestKitPicker}" Tapped="OnLabelTapped" />
-                                </Label.GestureRecognizers>
-                            </Label>
+                                x:Name="FinalTestKitLabel" />
 
                             <!--  Inputs Row  -->
-                            <Picker
+                            <Entry
                                 Grid.Column="0"
                                 Grid.Row="1"
-                                ItemsSource="{Binding TesterNoOptions}"
-                                SelectedItem="{Binding FinalTesterNo}"
-                                Style="{StaticResource FormPicker}"
-                                x:Name="FinalTesterNoPicker" />
-                            <Picker
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding FinalTesterNo}"
+                                x:Name="FinalTesterNo" />
+                            <Entry
                                 Grid.Column="1"
                                 Grid.Row="1"
-                                ItemsSource="{Binding TestKitSerialOptions}"
-                                SelectedItem="{Binding FinalTestKitSerial}"
-                                Style="{StaticResource FormPicker}"
-                                x:Name="FinalTestKitPicker" />
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding FinalTestKitSerial}"
+                                x:Name="FinalTestKit" />
                         </Grid>
                     </VerticalStackLayout>
                 </VerticalStackLayout>

--- a/Views/SettingsView/SettingsViewPage.xaml
+++ b/Views/SettingsView/SettingsViewPage.xaml
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<ContentPage
+    Title="Settings"
+    x:Class="ReportFlow.Views.SettingsView.SettingsViewPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:settingsViewModels="using:ReportFlow.ViewModels.SettingsViewModel"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+
+    <ContentPage.BindingContext>
+        <settingsViewModels:SettingsViewModel />
+    </ContentPage.BindingContext>
+
+    <ScrollView Style="{StaticResource PageLayout}">
+        <VerticalStackLayout Style="{StaticResource ContentStack}">
+            <Frame Style="{StaticResource CollapsibleSection}">
+                <VerticalStackLayout Spacing="0">
+                    <Button
+                        Clicked="OnSectionButtonClicked"
+                        Style="{StaticResource SectionHeader}"
+                        Text="Tester Information ▼"
+                        x:Name="TestInfoButton" />
+
+                    <VerticalStackLayout Style="{StaticResource SectionContent}" x:Name="TesterInfoContent">
+                        <Grid
+                            ColumnDefinitions="*,*"
+                            RowDefinitions="Auto,Auto,Auto,Auto"
+                            Style="{StaticResource FormGrid}">
+                            <Label
+                                Grid.Column="0"
+                                Grid.Row="0"
+                                Style="{StaticResource FieldLabel}"
+                                Text="Tester Name" />
+                            <Label
+                                Grid.Column="1"
+                                Grid.Row="0"
+                                Style="{StaticResource FieldLabel}"
+                                Text="Test Kit Serial" />
+
+                            <Entry
+                                Grid.Column="0"
+                                Grid.Row="1"
+                                Placeholder="Tester Name"
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding TesterName}" />
+                            <Entry
+                                Grid.Column="1"
+                                Grid.Row="1"
+                                Placeholder="Test Kit Serial"
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding TestKitSerial}" />
+
+                            <Label
+                                Grid.Column="0"
+                                Grid.Row="2"
+                                Style="{StaticResource FieldLabel}"
+                                Text="Test Cert No." />
+                            <Label
+                                Grid.Column="1"
+                                Grid.Row="2"
+                                Style="{StaticResource FieldLabel}"
+                                Text="Repair Cert No." />
+
+                            <Entry
+                                Grid.Column="0"
+                                Grid.Row="3"
+                                Placeholder="Test Cert No."
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding TestCertNo}" />
+                            <Entry
+                                Grid.Column="1"
+                                Grid.Row="3"
+                                Placeholder="Repair Cert No."
+                                Style="{StaticResource FormEntry}"
+                                Text="{Binding RepairCertNo}" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Button
+                Command="{Binding SaveCommand}"
+                Style="{StaticResource PrimaryButton}"
+                Text="Save" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/Views/SettingsView/SettingsViewPage.xaml.cs
+++ b/Views/SettingsView/SettingsViewPage.xaml.cs
@@ -1,0 +1,31 @@
+﻿namespace ReportFlow.Views.SettingsView;
+
+public partial class SettingsViewPage : ContentPage
+{
+    public SettingsViewPage()
+    {
+        InitializeComponent();
+    }
+
+    private void OnSectionButtonClicked(object? sender, EventArgs e)
+    {
+        if (sender is Button button)
+        {
+            // Get the content section based on button name
+            var contentName = button.Text.Contains("Test") ? "TesterInfoContent" : "RepresentativeSectionContent";
+
+            var content = FindByName(contentName) as VerticalStackLayout;
+            if (content != null)
+            {
+                // Toggle visibility
+                content.IsVisible = !content.IsVisible;
+
+                // Update button text
+                button.Text = button.Text.Replace(
+                    content.IsVisible ? "▶" : "▼",
+                    content.IsVisible ? "▼" : "▶"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- Add settings page with collapsible form for tester information
- Convert dropdown selectors to text entry fields
- Implement data persistence using Preferences API
- Set default form values from saved settings
- Bump version to 1.9.0
