### PR TITLE
Fixed FinalInfo Fatal Null Error

### DIFF
--- a/Models/ReportData.cs
+++ b/Models/ReportData.cs
@@ -48,6 +48,10 @@ public class ReportData
 
             FinalInfo = FinalInfo.FromFormFields(oldPdfData);
         }
+        else
+        {
+            FinalInfo = new FinalInfo();
+        }
     }
 
     public Dictionary<string, string> ToFormFields()

--- a/ReportFlow.csproj
+++ b/ReportFlow.csproj
@@ -18,7 +18,7 @@
         <ApplicationId>com.anybackflow.reportflow</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>1.9.6</ApplicationDisplayVersion>
+        <ApplicationDisplayVersion>1.9.7</ApplicationDisplayVersion>
         <ApplicationVersion>1</ApplicationVersion>
 
         <!-- Build Time Optimization -->


### PR DESCRIPTION
## Quick Hotfix
- Fixed null FinalInfoViewModel causing crash in v1.9.6